### PR TITLE
Fix Obsolete warning on SignOutSessionStateManager

### DIFF
--- a/src/BlazingPizza.Client/Shared/LoginDisplay.razor
+++ b/src/BlazingPizza.Client/Shared/LoginDisplay.razor
@@ -1,5 +1,4 @@
 ﻿@inject NavigationManager Navigation
-@inject SignOutSessionStateManager SignOutManager
 
 <div class="user-info">
     <AuthorizeView>
@@ -21,9 +20,8 @@
 </div>
 
 @code{
-    async Task BeginSignOut()
+    void BeginSignOut()
     {
-        await SignOutManager.SetSignOutState();
-        Navigation.NavigateTo("authentication/logout");
+        Navigation.NavigateToLogout("authentication/logout");
     }
 }


### PR DESCRIPTION
BlazingPizza.Client has a warning on an obsolete method. 

`
'SignOutSessionStateManager' is obsolete: 'Use 'Microsoft.AspNetCore.Components.Webassembly.Authentication.NavigationManagerExtensions.NavigateToLogout' instead.'`

This matches what the dotnet cli new blazor wasm template generates.